### PR TITLE
Amend to lowercase

### DIFF
--- a/00-Home.md
+++ b/00-Home.md
@@ -1,7 +1,12 @@
-Hydrus
+hydrus
 ===================
-Hydrus is a set of **Python** based tools for easier and efficient creation of Hypermedia driven REST-APIs. Hydrus utilises the power of [Linked Data](https://en.wikipedia.org/wiki/Linked_data) to create a powerful REST APIs to serve data.
-Hydrus uses the [Hydra(W3C)](http://www.hydra-cg.com/) standard for creation and documentation of it's APIs.
+
+hydrus (all lowercase) is the flagship tool in the ecosystem. It is a Flask server meant to build and deploy HYDRA-based Web APIs in
+ a straightforward and effective way. It uses Docker as virtualization and isolation technology (see Usage). Other tools,
+ as dedicated clients for testing, instances running with others frameworks, parsers/translators to other standards, are in the same ecosystem.
+
+hydrus is a set of **Python** based tools for easier and efficient creation of Hypermedia driven REST-APIs. hydrus utilises the power of [Linked Data](https://en.wikipedia.org/wiki/Linked_data) to create a powerful REST APIs to serve data.
+hydrus uses the [Hydra(W3C)](http://www.hydra-cg.com/) standard for creation and documentation of it's APIs.
 
 Table of contents
 -------------
@@ -14,7 +19,7 @@ Table of contents
 <a name="features"></a>
 Features
 -------------
-Hydrus supports the following features:
+hydrus supports the following features:
 - A client that can understand Hydra vocabulary and interacts with a Hydra supporting server to basic [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operations on data.
 - A generic server that can serve required data and metadata(in the form of API documentation) to a client over HTTP.
 - A middleware that allows users to use the client to interact with the server using Natural Language which is processed machine consumable language. **(under developement)**
@@ -28,7 +33,7 @@ The system is built over the following standards and tools:
 - [Hydra](http://www.hydra-cg.com/) as the API standard.
 - [SQLAlchemy](http://www.sqlalchemy.org/) as the backend database connector for storage and related operations.
 
-Apart from this, there are also various Python packages that Hydrus uses. A list of all these packages can be found in the [requirements.txt](https://github.com/HTTP-APIs/hydrus/blob/master/requirements.txt) file. It would be advisable to run **`pip install -r requirements.txt`** before setting up other things.
+Apart from this, there are also various Python packages that hydrus uses. A list of all these packages can be found in the [requirements.txt](https://github.com/HTTP-APIs/hydrus/blob/master/requirements.txt) file. It would be advisable to run **`pip install -r requirements.txt`** before setting up other things.
 
 
 **NOTE:** You'll need to use `python3` not `python2`.
@@ -36,9 +41,9 @@ Apart from this, there are also various Python packages that Hydrus uses. A list
 <a name="demo"></a>
 Demo
 -------------
-To run a demo for Hydrus using the sample API, just do the following:
+To run a demo for hydrus using the sample API, just do the following:
 
-Clone Hydrus:
+Clone hydrus:
 ```bash
 git clone https://github.com/HTTP-APIs/hydrus
 ```
@@ -61,9 +66,9 @@ The demo should be up and running on `http://localhost:8080/serverapi/`
 <a name="usage"></a>
 Usage
 -------------
-To understand how to use Hydrus and how things work, head over to the [Usage](01-Usage.md) page of the wiki.
+To understand how to use hydrus and how things work, head over to the [Usage](01-Usage.md) page of the wiki.
 
 <a name="design"></a>
 Design
 -------------
-Head over to the [Design](Design.md) page to understand the design principles and use cases of Hydrus.
+Head over to the [Design](Design.md) page to understand the design principles and use cases of hydrus.

--- a/00-Home.md
+++ b/00-Home.md
@@ -1,7 +1,7 @@
 hydrus
 ===================
 
-hydrus (all lowercase) is the flagship tool in the ecosystem. It is a Flask server meant to build and deploy HYDRA-based Web APIs in
+hydrus (fully lowercase) is the flagship tool in the ecosystem. It is a Flask server meant to build and deploy HYDRA-based Web APIs in
  a straightforward and effective way. It uses Docker as virtualization and isolation technology (see Usage). Other tools,
  as dedicated clients for testing, instances running with others frameworks, parsers/translators to other standards, are in the same ecosystem.
 

--- a/01-Usage.md
+++ b/01-Usage.md
@@ -1,4 +1,4 @@
-This page explains the basic usage and setting up a Hydra server using Hydrus.
+This page explains the basic usage and setting up a Hydra server using hydrus.
 
 Table of contents
 -------------
@@ -15,10 +15,10 @@ Table of contents
 
 <a name="servsetup"></a>
 ## Setting up the server
-Hydrus is a generic server that can serve a REST based API, using the Hydra APIDocumentation to understand the kind of data and the operations supported by the API. Getting a server running in Hydrus is pretty straight forward. All you need to do is create a script that plugs the API Documentation, the database and a few other variables and start a Hydrus app. An example of this is given below, in the following subsections, we will adress each part of the script and teach you how to create your own API using your API Documentation.
+hydrus is a generic server that can serve a REST based API, using the Hydra APIDocumentation to understand the kind of data and the operations supported by the API. Getting a server running in hydrus is pretty straight forward. All you need to do is create a script that plugs the API Documentation, the database and a few other variables and start a hydrus app. An example of this is given below, in the following subsections, we will adress each part of the script and teach you how to create your own API using your API Documentation.
 
 ```python
-"""Demo script for setting up an API using Hydrus."""
+"""Demo script for setting up an API using hydrus."""
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -56,7 +56,7 @@ properties = doc_parse.get_all_properties(classes)
 doc_parse.insert_classes(classes, session)
 doc_parse.insert_properties(properties, session)
 
-# Create a Hydrus app with the API name you want, default will be "api"
+# Create a hydrus app with the API name you want, default will be "api"
 app = app_factory(API_NAME)
 
 # Set the name of the API
@@ -67,7 +67,7 @@ with set_api_name(app, API_NAME):
         with set_hydrus_server_url(app, HYDRUS_SERVER_URL):
             # Set the Database session
             with set_session(app, session):
-                # Start the Hydrus app
+                # Start the hydrus app
                 app.run(host='127.0.0.1', debug=True, port=8080)
 ```
 
@@ -75,13 +75,13 @@ We will now break down each of these steps and understand what they really do. L
 
 <a name="apidoc"></a>
 ## The APIDocumentation
-Much of Hydrus is built around the Hydra API Documentation. The API Doc is defined in the Hydra spec [here](http://www.hydra-cg.com/spec/latest/core/).
-The API Doc is the entity that tells Hydrus how the server must be set up, what are the endpoints that must be created, what data needs to be served, the operations supported by the data and so on.
-Hydrus uses Python classes in `hydrus.hydraspec.doc_writer` to create/define API Docs. A description of these classes and their design can be found in the [Design](https://github.com/HTTP-APIs/hydrus/wiki/Design) section.
+Much of hydrus is built around the Hydra API Documentation. The API Doc is defined in the Hydra spec [here](http://www.hydra-cg.com/spec/latest/core/).
+The API Doc is the entity that tells hydrus how the server must be set up, what are the endpoints that must be created, what data needs to be served, the operations supported by the data and so on.
+hydrus uses Python classes in `hydrus.hydraspec.doc_writer` to create/define API Docs. A description of these classes and their design can be found in the [Design](https://github.com/HTTP-APIs/hydrus/wiki/Design) section.
 
 <!-- ![doc_writer](https://image.ibb.co/eWURkQ/doc_writer.png) -->
 
-The `hydurs.hydraspec.doc_writer.HydraDoc` object is crucial for Hydrus to be able to set up the API. There are a number of ways you can create this object from your API Documentation:
+The `hydurs.hydraspec.doc_writer.HydraDoc` object is crucial for hydrus to be able to set up the API. There are a number of ways you can create this object from your API Documentation:
 
 <a name="newdoc"></a>
 ### Create a new API Documentation and a new `HydraDoc` object
@@ -118,7 +118,7 @@ class_title = "dummyClass"  # Title of the Class
 class_description = "A dummyClass for demo"     # Description of the class
 class_ = HydraClass(class_uri, class_title, class_description, endpoint=False)
 # Setting endpoint=True creates an endpoint for the class itself, this is usually for classes that have single instances
-# These classes should not ideally have a Collection, although Hydrus allows creation of such Collections
+# These classes should not ideally have a Collection, although hydrus allows creation of such Collections
 ```
 Classes need to have properties that allow them to store information related to the class, much like attributes in a Python class, these are stored as `supportedProperty` of the `HydraClass`. Properties are defined as `HydraClassProp` objects:
 ```python
@@ -197,7 +197,7 @@ The complete script for this API Documentation can be found in `hydrus/hydraspec
 <a name="olddoc"></a>
 ### Use an existing API Documentation to create a new `HydraDoc` object
 
-In case you already have an API Doc defined in JSON or a Python dict, Hydrus provides a way to turn this API Doc into `doc_writer` classes. This is done using `hydrus.hydraspec.doc_maker` as defined below:
+In case you already have an API Doc defined in JSON or a Python dict, hydrus provides a way to turn this API Doc into `doc_writer` classes. This is done using `hydrus.hydraspec.doc_maker` as defined below:
 ```python
 # Sample to convert the API Doc into doc_writer classes
 
@@ -227,10 +227,10 @@ JSON variables can such as `true`, `false` and `null` can be used as strings. Py
 
 <a name="dbsetup"></a>
 ## Setting up the database
-Now that we have defined the API Documentation, the next thing Hydrus needs to function is a database to store the actual resources of the API. Hydrus has it's own database models that are generic and can be used for most APIs, more information about these can be found in the [Design](https://github.com/HTTP-APIs/hydrus/wiki/Design) section.
+Now that we have defined the API Documentation, the next thing hydrus needs to function is a database to store the actual resources of the API. hydrus has it's own database models that are generic and can be used for most APIs, more information about these can be found in the [Design](https://github.com/HTTP-APIs/hydrus/wiki/Design) section.
 
 The databse models use SQLAlchemy as an ORM Layer mapping relations to Python Classs and Objects. A good reference for the ORM can be found [here](http://docs.sqlalchemy.org/en/rel_1_0/orm/tutorial.html).
-Here is how we can create a new connection and create the necessary models for Hydrus to use.
+Here is how we can create a new connection and create the necessary models for hydrus to use.
 
 A new connection to a database can be created as follows:
 ```python
@@ -240,7 +240,7 @@ engine = create_engine('sqlite:///path/to/database/file')
 ```
 This engine acts as a connection on which we can create sessions to interact with the database. You can use any other database, we have used SQLite for the purpose of this demo. A list of possible database and how to connect to them can be found [here](http://docs.sqlalchemy.org/en/rel_1_0/orm/tutorial.html).
 
-Once we have connected to the database we need to create the necessary models from Hydrus:
+Once we have connected to the database we need to create the necessary models from hydrus:
 
 ```python
 from hydrus.data.db_models import Base
@@ -251,7 +251,7 @@ This will successfully create all required models in the connected database. The
 
 <a name="classprop"></a>
 ## Adding Classes and Properties
-To add the classes and properties to Hydrus, we need the same database `engine` in which we earlier created the models for Hydrus. To this, we will add metadata using the HydraDoc object. This can be done using the `doc_parse` module in Hydrus.
+To add the classes and properties to hydrus, we need the same database `engine` in which we earlier created the models for hydrus. To this, we will add metadata using the HydraDoc object. This can be done using the `doc_parse` module in hydrus.
 
 ```python
 from hydrus.data import doc_parse
@@ -297,23 +297,23 @@ doc_parse.insert_properties(classes, session=db_session)
 
 <a name="urls"></a>
 ## Server URL and the API name
-Hydrus needs to know the server URL defined as `HYDRUS_SERVER_URL` at which it is hosted and the API name defined as `API_NAME`, which also serves as the entrypoint for the API.
+hydrus needs to know the server URL defined as `HYDRUS_SERVER_URL` at which it is hosted and the API name defined as `API_NAME`, which also serves as the entrypoint for the API.
 
-These are used to define IDs for objects/resources that Hydrus serves. For example, a Hydrus server hosted at `https://hydrus.com/api` must return objects with ID `@id: https://hydrus.com/api/dummyClass/1`.
+These are used to define IDs for objects/resources that hydrus serves. For example, a hydrus server hosted at `https://hydrus.com/api` must return objects with ID `@id: https://hydrus.com/api/dummyClass/1`.
 
-It is essential for Hydrus to know this, as the Hydra spec requres IDs for objects to be dereferencable links.
-Since most servers use an interface to link with the actual application or backend process, these things cannot be found out by Hydrus on it's own and must be provided during setup.
+It is essential for hydrus to know this, as the Hydra spec requres IDs for objects to be dereferencable links.
+Since most servers use an interface to link with the actual application or backend process, these things cannot be found out by hydrus on it's own and must be provided during setup.
 
 <a name="appf"></a>
 ## App factory
-The API name, must also be used for Hydrus to actually create an app. The `app_factory` method creates an API with all routes directed at `/[API_NAME]`, for example if you create an app using the `API_NAME` as `"demoapi"`, all operations for the API will be at the route `/demoapi/..`. The API name serves as the entrypoint for the application. We can create an app using the `API_NAME` as follows:
+The API name, must also be used for hydrus to actually create an app. The `app_factory` method creates an API with all routes directed at `/[API_NAME]`, for example if you create an app using the `API_NAME` as `"demoapi"`, all operations for the API will be at the route `/demoapi/..`. The API name serves as the entrypoint for the application. We can create an app using the `API_NAME` as follows:
 
 ```python
 from hydrus.app import app_factory
 
 API_NAME = 'demoapi'
 
-# Create a Hydrus app with the API name you want, default will be "api"
+# Create a hydrus app with the API name you want, default will be "api"
 app = app_factory(API_NAME)
 ```
 <a name="pnp"></a>
@@ -330,10 +330,10 @@ with set_api_name(app, API_NAME):
         with set_hydrus_server_url(app, HYDRUS_SERVER_URL):
             # Set the Database session
             with set_session(app, session):
-                # Start the Hydrus app
+                # Start the hydrus app
                 app.run(host='127.0.0.1', debug=True, port=8080)
 ```
-The Hydrus app is a modified instance of the Flask app with the required operations and routes predefined. All options/operations on the app object will be the same as those done in the Flask app.
+The hydrus app is a modified instance of the Flask app with the required operations and routes predefined. All options/operations on the app object will be the same as those done in the Flask app.
 
 <a name="test"></a>
 ## Running tests

--- a/Auth.md
+++ b/Auth.md
@@ -1,4 +1,6 @@
-This page explains the authentication options you can apply to your API.
+# Token Authentication
+
+This page explains the authentication options you can apply to your API deployed with hydrus.
 
 ### How to enable authentication?
 

--- a/Design.md
+++ b/Design.md
@@ -1,4 +1,4 @@
-This page explains the design, architecture and the implementation of Hydrus along with a few use cases for the same.
+This page explains the design, architecture and the implementation of hydrus along with a few use cases for the same.
 
 Table of contents
 -------------
@@ -24,7 +24,7 @@ Below is the schema diagram for our database design:
 
 <a name="dataflow"></a>
 ### Data Flow
-Here is a small illustration as to how data flows in Hydrus.
+Here is a small illustration as to how data flows in hydrus.
 
 Hydra API Documentation to server endpoints:
 
@@ -36,10 +36,10 @@ RDF/OWL declarations to server endpoints:
 
 <a name="usecase"></a>
 ### Use cases
-This section explains Hydrus's design and a use case for the same.
+This section explains hydrus's design and a use case for the same.
 For the demonstration, the server has the [Subsystems](http://ontology.projectchronos.eu/documentation/subsystems) and [Spacecraft](http://ontology.projectchronos.eu/documentation/spacecraft) vocabularies.
 
-Here is an example of a system used to serve data using the components of Hydrus:
+Here is an example of a system used to serve data using the components of hydrus:
 
 ![Use case](https://github.com/HTTP-APIs/hydrus/blob/develop/docs/wiki/images/use_case1.png?raw=true "Use case")
 
@@ -73,7 +73,7 @@ instance = {
 }
 
 ```
-Once we have defined such an `instance`, we can use the built-in CRUD operations of Hydrus to add these instances.
+Once we have defined such an `instance`, we can use the built-in CRUD operations of hydrus to add these instances.
 ```python
 from hydrus.data import crud
 

--- a/Starting-Material.md
+++ b/Starting-Material.md
@@ -6,7 +6,6 @@
 4. Read [hydrus WIKI](https://github.com/HTTP-APIs/hydrus/wiki). Run `hydrus` and try to set up a basic API. Read the [documentation](http://hydrus.readthedocs.io/en/latest/)
 5. If you want to have fun with a more dynamic demo, run [hydra-flock-demo](https://github.com/HTTP-APIs/hydra-flock-demo)
 6. There are different rooms in Gitter in which to interact with other contributors:
-* [Study Room: share what you have found!](https://gitter.im/HTTP-APIs/Improving-Hydrus)
 * [Demos room: talk about creating new demo implementations](https://gitter.im/HTTP-APIs/Demos-creation)
 * [Improving hydrus room: issues, solutions and ideas](https://gitter.im/HTTP-APIs/Improving-Hydrus)
 * [Beginners: experienced contributors help newcomers](https://gitter.im/HTTP-APIs/Beginners)


### PR DESCRIPTION
Suggestion for consistency of vocabulary. I thought about limiting the usage of the name `hydrus` to **fully lowercase**, both to avoid excess formalism and also to make it uniform with the repository name.
So what I am doing in everything I write, I try to remember to always use lowercase `h` even at the beginning of the paragraph and after a dot. I think it could be also a fair move in terms of branding, as HYDRA usually appear fully uppercase, so hydrus should appear fully lowercase.